### PR TITLE
Add tests to list paging scenarios

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -47,6 +47,9 @@ jobs:
     name: "Instrumented tests"
     runs-on: ubuntu-latest
     timeout-minutes: 55
+    strategy:
+      matrix:
+        api-level: [ 26, 33 ]
 
     steps:
       # From https://github.com/android/nowinandroid/pull/1219/files to fix flaky emulator start
@@ -89,17 +92,17 @@ jobs:
       - name: Run android tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: ${{ matrix.api-level }}
           arch: x86_64
           disable-animations: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disk-size: 6000M
           heap-size: 600M
-          script: ./gradlew connectedDemoDebugAndroidTest --daemon
+          script: ./gradlew connectedDemoDebugAndroidTest
 
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.api-level }}
           path: '**/build/reports/androidTests'

--- a/app/src/androidTest/java/br/com/cattose/app/AppTest.kt
+++ b/app/src/androidTest/java/br/com/cattose/app/AppTest.kt
@@ -76,7 +76,7 @@ class AppTest {
 
             onDevice().setScreenOrientation(ScreenOrientation.LANDSCAPE)
 
-            onNodeWithTag(ListTestTags.LOADING).assertIsNotDisplayed()
+            onNodeWithTag(ListTestTags.INITIAL_LOADING).assertIsNotDisplayed()
 
             onNodeWithTag(ListTestTags.LAZY_GRID)
                 .onChildren()

--- a/feature/detail/src/main/java/br/com/cattose/app/feature/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/br/com/cattose/app/feature/detail/DetailScreen.kt
@@ -165,10 +165,9 @@ fun SharedTransitionScope.DetailsHeader(
             contentScale = contentScale,
             modifier = modifier
                 .align(Alignment.TopStart)
-                .sharedBounds(
-                    sharedContentState = rememberSharedContentState(key = imageUrl),
+                .sharedElement(
+                    state = rememberSharedContentState(key = imageUrl),
                     animatedVisibilityScope = animatedVisibilityScope,
-                    placeHolderSize = SharedTransitionScope.PlaceHolderSize.animatedSize,
                     renderInOverlayDuringTransition = false // for the back button to show during transition
                 )
                 .testTag(DetailTestTags.IMAGE)

--- a/feature/list/src/main/java/br/com/cattose/app/feature/list/ListScreen.kt
+++ b/feature/list/src/main/java/br/com/cattose/app/feature/list/ListScreen.kt
@@ -42,6 +42,11 @@ import br.com.cattose.app.core.ui.error.TryAgain
 import br.com.cattose.app.core.ui.image.DefaultAsyncImage
 import br.com.cattose.app.core.ui.image.ImagePlaceholder
 import br.com.cattose.app.data.model.domain.CatImage
+import br.com.cattose.app.feature.list.ListTestTags.APPEND_LOADING
+import br.com.cattose.app.feature.list.ListTestTags.EMPTY_LIST
+import br.com.cattose.app.feature.list.ListTestTags.ERROR
+import br.com.cattose.app.feature.list.ListTestTags.INITIAL_LOADING
+import br.com.cattose.app.feature.list.ListTestTags.LAZY_GRID
 import coil.transform.RoundedCornersTransformation
 
 
@@ -84,7 +89,7 @@ fun SharedTransitionScope.ListScreenContent(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .testTag(ListTestTags.LOADING),
+                        .testTag(INITIAL_LOADING),
                     contentAlignment = Alignment.Center
                 ) {
                     CircularProgressIndicator()
@@ -100,23 +105,23 @@ fun SharedTransitionScope.ListScreenContent(
                     onTryAgainClick = {
                         lazyPagingItems.refresh()
                     },
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize().testTag(ERROR)
                 )
             }
             refreshState.endRefresh()
         }
 
         is LoadState.NotLoading -> {
-            if (lazyPagingItems.itemSnapshotList.isEmpty() &&
-                lazyPagingItems.loadState.append.endOfPaginationReached
-            ) {
+            if (lazyPagingItems.itemSnapshotList.isEmpty()) {
                 TryAgain(
                     message = stringResource(id = R.string.empty_state_message),
                     tryAgainActionText = stringResource(id = br.com.cattose.app.core.ui.R.string.action_retry),
                     onTryAgainClick = {
                         lazyPagingItems.refresh()
                     },
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(EMPTY_LIST)
                 )
             }
             refreshState.endRefresh()
@@ -135,7 +140,7 @@ fun SharedTransitionScope.ListScreenContent(
             columns = StaggeredGridCells.Fixed(columns),
             modifier = modifier
                 .padding(8.dp)
-                .testTag(ListTestTags.LAZY_GRID)
+                .testTag(LAZY_GRID)
         ) {
             items(lazyPagingItems.itemCount) {
                 lazyPagingItems[it]?.let {
@@ -168,7 +173,8 @@ fun SharedTransitionScope.ListScreenContent(
                             Column(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(16.dp),
+                                    .padding(16.dp)
+                                    .testTag(APPEND_LOADING),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                                 verticalArrangement = Arrangement.Center,
                             ) {
@@ -200,10 +206,9 @@ fun SharedTransitionScope.CatListItem(
         modifier = modifier
             .clickable { onItemClick(cat) }
             .wrapContentSize()
-            .sharedBounds(
-                sharedContentState = rememberSharedContentState(key = cat.imageUrl),
-                animatedVisibilityScope = animatedVisibilityScope,
-                placeHolderSize = SharedTransitionScope.PlaceHolderSize.contentSize
+            .sharedElement(
+                state = rememberSharedContentState(key = cat.imageUrl),
+                animatedVisibilityScope = animatedVisibilityScope
             )
             .clip(RoundedCornerShape(8.dp))
             .testTag(cat.id),

--- a/feature/list/src/main/java/br/com/cattose/app/feature/list/ListTestTags.kt
+++ b/feature/list/src/main/java/br/com/cattose/app/feature/list/ListTestTags.kt
@@ -2,6 +2,9 @@ package br.com.cattose.app.feature.list
 
 object ListTestTags {
     const val LAZY_GRID = "lazyGrid"
-    const val LOADING = "loading"
+    const val INITIAL_LOADING = "loading"
+    const val APPEND_LOADING = "appendLoading"
+    const val EMPTY_LIST = "emptyList"
+    const val ERROR = "error"
 }
 


### PR DESCRIPTION
- fix empty state logic
- add tests for min API (Needed to remove MockK from mocking lazy paging items).
- add tests for paging scenarios.
- fix transitions crash