### PR TITLE
Add snapshot tests with Paparazzi

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
 
   test_and_build:
-    name: "Unit tests and Build"
+    name: "Unit and Snapshot tests and Build debug APK"
     runs-on: ubuntu-latest
 
     permissions:
@@ -43,6 +43,9 @@ jobs:
 
       - name: Unit tests
         run: ./gradlew testDemoDebugUnitTest
+
+      - name: Snapshot tests
+        run: ./gradlew core:ui:verifyPaparazziDemoDebug
 
       - name: Build APK
         run: ./gradlew app:assembleDebug

--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
@@ -41,11 +43,11 @@ jobs:
       - name: Check build-logic
         run: ./gradlew check -p build-logic
 
-      - name: Unit tests
-        run: ./gradlew testDemoDebugUnitTest
-
       - name: Snapshot tests
         run: ./gradlew core:ui:verifyPaparazziDemoDebug
+
+      - name: Unit tests
+        run: ./gradlew testDemoDebugUnitTest
 
       - name: Build APK
         run: ./gradlew app:assembleDebug

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ aligned to [Android Architecture Guide](https://developer.android.com/topic/arch
 - [MocKK](https://mockk.io/)
 - [Truth](https://truth.dev/)
 - [Turbine](https://github.com/cashapp/turbine)
+- [Paparazzi](https://github.com/cashapp/paparazzi)
 
 ## Screenshots
 |                               List screen                                |                               Detail screen                               |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,5 @@ plugins {
     alias(libs.plugins.secrets) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.compose.compiler) apply false
+    alias(libs.plugins.paparazzi) apply false
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.cattose.android.library)
     alias(libs.plugins.cattose.library.compose)
     alias(libs.plugins.cattose.library.jacoco)
+    alias(libs.plugins.paparazzi)
 }
 
 android {
@@ -27,4 +28,6 @@ dependencies {
     api(libs.coil)
     api(libs.coil.compose)
     api(libs.coil.gif)
+
+    testImplementation(libs.google.testParameterInjector)
 }

--- a/core/ui/src/main/java/br/com/cattose/app/core/ui/theme/Theme.kt
+++ b/core/ui/src/main/java/br/com/cattose/app/core/ui/theme/Theme.kt
@@ -62,9 +62,10 @@ fun CattoTheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            (view.context as? Activity)?.window?.let { window ->
+                window.statusBarColor = colorScheme.primary.toArgb()
+                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            }
         }
     }
 

--- a/core/ui/src/test/kotlin/br/com/cattose/app/core/ui/PaparazziConfig.kt
+++ b/core/ui/src/test/kotlin/br/com/cattose/app/core/ui/PaparazziConfig.kt
@@ -1,0 +1,19 @@
+package br.com.cattose.app.core.ui
+
+import app.cash.paparazzi.DeviceConfig
+import com.android.resources.ScreenOrientation
+
+enum class PaparazziDefaultDeviceConfig(
+    val deviceConfig: DeviceConfig
+) {
+    PIXEL_4(deviceConfig = DeviceConfig.PIXEL_4),
+    PIXEL_6(deviceConfig = DeviceConfig.PIXEL_6),
+    PIXEL_6_LANDSCAPE(deviceConfig = DeviceConfig.PIXEL_6.copy(orientation = ScreenOrientation.LANDSCAPE)),
+    NEXUS_10_TABLET(deviceConfig = DeviceConfig.NEXUS_10)
+}
+
+enum class PaparazziTheme(
+    val themeName: String
+) {
+    MATERIAL_LIGHT_NO_ACTION_BAR(themeName = "android:Theme.Material.Light.NoActionBar")
+}

--- a/core/ui/src/test/kotlin/br/com/cattose/app/core/ui/TagsSnapshotTest.kt
+++ b/core/ui/src/test/kotlin/br/com/cattose/app/core/ui/TagsSnapshotTest.kt
@@ -1,0 +1,32 @@
+package br.com.cattose.app.core.ui
+
+import app.cash.paparazzi.Paparazzi
+import br.com.cattose.app.core.ui.tags.TagListPreview
+import com.android.resources.NightMode
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class TagsSnapshotTest(
+    @TestParameter config: PaparazziDefaultDeviceConfig,
+    @TestParameter nightMode: NightMode
+) {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = config.deviceConfig.copy(
+            nightMode = nightMode
+        ),
+        theme = PaparazziTheme.MATERIAL_LIGHT_NO_ACTION_BAR.themeName
+    )
+
+    @Test
+    fun tagListSnapshotTest() {
+        paparazzi.snapshot {
+            TagListPreview()
+        }
+    }
+}

--- a/core/ui/src/test/kotlin/br/com/cattose/app/core/ui/TryAgainSnapshotTest.kt
+++ b/core/ui/src/test/kotlin/br/com/cattose/app/core/ui/TryAgainSnapshotTest.kt
@@ -1,0 +1,32 @@
+package br.com.cattose.app.core.ui
+
+import app.cash.paparazzi.Paparazzi
+import br.com.cattose.app.core.ui.error.TryAgainPreview
+import com.android.resources.NightMode
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class TryAgainSnapshotTest(
+    @TestParameter config: PaparazziDefaultDeviceConfig,
+    @TestParameter nightMode: NightMode
+) {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = config.deviceConfig.copy(
+            nightMode = nightMode
+        ),
+        theme = PaparazziTheme.MATERIAL_LIGHT_NO_ACTION_BAR.themeName
+    )
+
+    @Test
+    fun tryAgainSnapshotTest() {
+        paparazzi.snapshot {
+            TryAgainPreview()
+        }
+    }
+}

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[NEXUS_10_TABLET,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[NEXUS_10_TABLET,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fff88c46a6b58c5733f4a5ed6225c47abbbbfdce62a40a7ceffc837d2401d8a
+size 11785

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[NEXUS_10_TABLET,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[NEXUS_10_TABLET,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ff2235ebf03a62f73a732e048234eeafd8c4dd0526616890e51b9fe4a715bf1
+size 12034

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_4,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_4,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2d8b7b50ba47eaae9f27dcb84c27d814ca2f2ecb10d2a352a6b6838091bdc10
+size 18116

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_4,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_4,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0555a48c97f19e92024a324f55c62b77b60ead1f1365146514a5940542f1b953
+size 18483

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca3472f0e66187163f49fbb0a425f4be96a3659959723870f6c3ecf013b94a0e
+size 16172

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1475c6b5caf18f7880486d907c4305544380e7c377988ceea527ff0e290bd44
+size 16421

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6_LANDSCAPE,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6_LANDSCAPE,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75a83cffddb814fd2ff8570eba3e783ea287f26730a2fb423df463aa536640a7
+size 11386

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6_LANDSCAPE,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TagsSnapshotTest_tagListSnapshotTest[PIXEL_6_LANDSCAPE,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67f7106cdfe8faa232e56a63a058acb07f97a5562d79d28193ca11628a8a128f
+size 11678

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[NEXUS_10_TABLET,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[NEXUS_10_TABLET,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48ffd14fd7dfb35946c2d6cc58815a5d5d526299d0cb5f6eefed9c53d4a6293a
+size 7314

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[NEXUS_10_TABLET,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[NEXUS_10_TABLET,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7e4fdcb50cb7b7dadf51d15d2eee8c0d9e8541b8711934265ff060580e70bbb
+size 7109

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_4,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_4,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67606d885f6e27682312885f88fcce162df78d5b38e812df050399bec339da22
+size 9417

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_4,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_4,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85f97522efc1e9057f86f4af49bff1b657bda7ab898e2341f488abdeb227fb99
+size 9121

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5508ea8945a10a1f3243d7c459abb2a854b63fb8cb2ecbea46a3bfc8035f01d2
+size 8563

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11e8edf497ecc807b103106efe6e8ca594bd8888a04bb1ceab6c1df2bf8e729d
+size 8317

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6_LANDSCAPE,NIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6_LANDSCAPE,NIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eaebdb7cd3753d590458b4035e2bd7184f73896d974ad51c819c8c47694e6f1
+size 7988

--- a/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6_LANDSCAPE,NOTNIGHT].png
+++ b/core/ui/src/test/snapshots/images/br.com.cattose.app.core.ui_TryAgainSnapshotTest_tryAgainSnapshotTest[PIXEL_6_LANDSCAPE,NOTNIGHT].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ecba68f8fb6650c6549ad0303f2957c7856c856b9ed4127f5c8daf5117aa70f
+size 7768

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ jacoco = "0.8.12"
 kotlinx-serialization = "1.7.0"
 desugar = "2.0.4"
 paparazzi = "1.3.4"
+test-parameter-injector = "1.16"
 
 
 [libraries]
@@ -90,7 +91,7 @@ espresso-device = { group = "androidx.test.espresso", name = "espresso-device", 
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 paging-test = { group = "androidx.paging", name = "paging-testing", version.ref = "paging3" }
-google-testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.16" }
+google-testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "test-parameter-injector" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -134,7 +135,7 @@ jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi"}
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 
 cattose-hilt = { id = "cattose.android.hilt", version = "unspecified" }
 cattose-android-application = { id = "cattose.android.application", version = "unspecified" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ navigation-compose = "2.8.0-alpha08"
 jacoco = "0.8.12"
 kotlinx-serialization = "1.7.0"
 desugar = "2.0.4"
+paparazzi = "1.3.4"
 
 
 [libraries]
@@ -89,6 +90,7 @@ espresso-device = { group = "androidx.test.espresso", name = "espresso-device", 
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 paging-test = { group = "androidx.paging", name = "paging-testing", version.ref = "paging3" }
+google-testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.16" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -132,6 +134,7 @@ jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi"}
 
 cattose-hilt = { id = "cattose.android.hilt", version = "unspecified" }
 cattose-android-application = { id = "cattose.android.application", version = "unspecified" }


### PR DESCRIPTION
- Added Paparazzi plugin into :core:ui module.
- Created screenshot tests for TagList and TryAgain components.
- Created device configuration to be used within parameterized tests.
- Added safe cast on window object in Theme.kt, because it was crashing in Paparazzi context.
- Added snapshot verify task on CI.